### PR TITLE
Make mul_add inline

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -711,6 +711,7 @@ where
     ///
     /// Using mul_add can be more performant than an unfused multiply-add if the
     /// target architecture has a dedicated fma CPU instruction.
+    #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         let mut result = Self::splat(B::zero());
         for ((res, &s), (&a, &b)) in result


### PR DESCRIPTION
Experience shows that rustc [can fail to inline it in some circumstances](https://internals.rust-lang.org/t/caller-side-inline-directives/19078/7?u=hadrieng), which is Very Bad.